### PR TITLE
Change misspelled name

### DIFF
--- a/the-codeless-code/en-qi/case-212.txt
+++ b/the-codeless-code/en-qi/case-212.txt
@@ -1,7 +1,7 @@
 Date: 2015-11-01
 Title: Seasons
 Number: 212
-Names: Qi, Spider Clan, Laughing Monkey Clan, Elephant's Footprint Clan, Ru Cheen, Shinpuru
+Names: Qi, Spider Clan, Laughing Monkey Clan, Elephant's Footprint Clan, Ruh Cheen, Shinpuru
 Topics: change, documentation, Agile
 Geekiness: 1
 Tagline: In which another leaf is turned.


### PR DESCRIPTION
In this koan, Ru Cheen is referenced in the Names tag. Nowhere else is he referenced, so I believe it to be a misspelling of Ruh Cheen. I've changed the reference to be to Ruh Cheen.

Should this change have been made in a new folder (e.g. en-jhprime)?